### PR TITLE
Remove have_vs_not search fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/admin/ingredients.rb
+++ b/app/admin/ingredients.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Ingredient do
   permit_params :ingredient_name, :have_vs_not
-
+  remove_filter :have_vs_not
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/views/ingredients/_ingredients_search_form.html.erb
+++ b/app/views/ingredients/_ingredients_search_form.html.erb
@@ -10,13 +10,13 @@
     <%= f.label :have_vs_not_eq, "Have vs not" %>
     <div>
       <label class="radio-inline">
-        <%= f.radio_button :have_vs_not_eq, "1", checked: ((params[:q] && params[:q][:have_vs_not_eq]) == "1" ? "checked" : "") %> Yes
+        <%# f.radio_button :have_vs_not_eq, "1", checked: ((params[:q] && params[:q][:have_vs_not_eq]) == "1" ? "checked" : "") %> Yes
       </label>
       <label class="radio-inline">
-        <%= f.radio_button :have_vs_not_eq, "0", checked: ((params[:q] && params[:q][:have_vs_not_eq]) == "0" ? "checked" : "")%> No
+        <%#= f.radio_button :have_vs_not_eq, "0", checked: ((params[:q] && params[:q][:have_vs_not_eq]) == "0" ? "checked" : "")%> No
       </label>
       <label class="radio-inline">
-        <%= f.radio_button :have_vs_not_eq, ""%> Either
+        <%#= f.radio_button :have_vs_not_eq, ""%> Either
       </label>
     </div>
   </div>


### PR DESCRIPTION
Hi @lauralpeng,

If you merge this change and deploy to Heroku again, you should be able to interact with the Ingredients page.